### PR TITLE
Camera Sensitivity is now one variable per input method

### DIFF
--- a/scripts/player_camera.gd
+++ b/scripts/player_camera.gd
@@ -116,13 +116,13 @@ func _physics_process(delta):
 	return
 
 func change_sensitivities():
-	controller_look_h_speed = UserSettings.c_cam_x_sense
-	controller_look_v_speed = UserSettings.c_cam_y_sense
+	controller_look_h_speed = UserSettings.c_cam_sense
+	controller_look_v_speed = UserSettings.c_cam_sense
 	controller_invert_look_h = UserSettings.c_invert_x
 	controller_invert_look_v = UserSettings.c_invert_y
 	
-	mouse_look_h_speed = UserSettings.m_cam_x_sense
-	mouse_look_v_speed = UserSettings.m_cam_y_sense
+	mouse_look_h_speed = UserSettings.m_cam_sense
+	mouse_look_v_speed = UserSettings.m_cam_sense
 	mouse_invert_look_h = UserSettings.m_invert_x
 	mouse_invert_look_v = UserSettings.m_invert_y
 	return

--- a/scripts/user_settings.gd
+++ b/scripts/user_settings.gd
@@ -3,13 +3,11 @@ extends Node
 # AUTOLOAD : UserSettings
 const FILE_PATH = "user://usersettings.cfg"
 
-var m_cam_x_sense : float = 0.25
-var m_cam_y_sense : float = 0.25
+var m_cam_sense : float = 0.25
 var m_invert_x : bool = true
 var m_invert_y : bool = false
 
-var c_cam_x_sense : int = 150
-var c_cam_y_sense : int = 150
+var c_cam_sense : int = 150
 var c_invert_x : bool = false
 var c_invert_y : bool = true
 
@@ -17,13 +15,11 @@ var s_music_level : float = 1.0
 var s_sfx_level : float = 1.0
 
 const DEFAULTS = {
-	"m_cam_x_sense": 0.25,
-	"m_cam_y_sense": 0.25,
+	"m_cam_sense": 0.25,
 	"m_invert_x": true,
 	"m_invert_y": false,
 	
-	"c_cam_x_sense": 150,
-	"c_cam_y_sense": 150,
+	"c_cam_sense": 150,
 	"c_invert_x": false,
 	"c_invert_y": true,
 	
@@ -33,13 +29,12 @@ const DEFAULTS = {
 
 func save_settings():
 	var config = ConfigFile.new()
-	config.set_value("M", "m_cam_x_sense", m_cam_x_sense)
-	config.set_value("M", "m_cam_y_sense", m_cam_y_sense)
+	
+	config.set_value("M", "m_cam_sense", m_cam_sense)
 	config.set_value("M", "m_invert_x", m_invert_x)
 	config.set_value("M", "m_invert_y", m_invert_y)
 	
-	config.set_value("C", "c_cam_x_sense", c_cam_x_sense)
-	config.set_value("C", "c_cam_y_sense", c_cam_y_sense)
+	config.set_value("C", "c_cam_sense", c_cam_sense)
 	config.set_value("C", "c_invert_x", c_invert_x)
 	config.set_value("C", "c_invert_y", c_invert_y)
 	
@@ -59,14 +54,13 @@ func load_settings():
 		if error == ERR_FILE_NOT_FOUND: # TODO - Handle more errors? Log errors?
 			_save_default_settings_file()
 		return
+		
 	
-	config.get_value("M", "m_cam_x_sense", DEFAULTS["m_cam_x_sense"])
-	config.get_value("M", "m_cam_y_sense", DEFAULTS["m_cam_y_sense"])
+	config.get_value("M", "m_cam_sense", DEFAULTS["m_cam_sense"])
 	config.get_value("M", "m_invert_x", DEFAULTS["m_invert_x"])
 	config.get_value("M", "m_invert_y", DEFAULTS["m_invert_y"])
 	
-	config.get_value("C", "c_cam_x_sense", DEFAULTS["c_cam_x_sense"])
-	config.get_value("C", "c_cam_y_sense", DEFAULTS["c_cam_y_sense"])
+	config.get_value("C", "c_cam_sense", DEFAULTS["c_cam_sense"])
 	config.get_value("C", "c_invert_x", DEFAULTS["c_invert_x"])
 	config.get_value("C", "c_invert_y", DEFAULTS["c_invert_y"])
 	
@@ -76,13 +70,11 @@ func load_settings():
 	
 func _save_default_settings_file():
 	var config = ConfigFile.new()
-	config.set_value("M", "m_cam_x_sense", DEFAULTS["m_cam_x_sense"])
-	config.set_value("M", "m_cam_y_sense", DEFAULTS["m_cam_y_sense"])
+	config.set_value("M", "m_cam_sense", DEFAULTS["m_cam_sense"])
 	config.set_value("M", "m_invert_x", DEFAULTS["m_invert_x"])
 	config.set_value("M", "m_invert_y", DEFAULTS["m_invert_y"])
 	
-	config.set_value("C", "c_cam_x_sense", DEFAULTS["c_cam_x_sense"])
-	config.set_value("C", "c_cam_y_sense", DEFAULTS["c_cam_y_sense"])
+	config.set_value("C", "c_cam_sense", DEFAULTS["c_cam_sense"])
 	config.set_value("C", "c_invert_x", DEFAULTS["c_invert_x"])
 	config.set_value("C", "c_invert_y", DEFAULTS["c_invert_y"])
 	


### PR DESCRIPTION
- Separate X and Y sensitivities for both M&K and controller have been replaced by a single sensitivity for each input method
- This makes the user's experience w/ changing sensitivities easier
- UserSetting's save file (`usersettings.cfg`) has been updated to only store and load 1 sensitivity per input method
- PlayerCamera now pulls the correct single sensitivity, despite still using variables for X and Y sensitivities internally. 